### PR TITLE
Decrease PDF font size

### DIFF
--- a/src/resume-view/Theme.tsx
+++ b/src/resume-view/Theme.tsx
@@ -33,7 +33,7 @@ export type Palette = {
 const exponentialSpacing = (size: number) =>
   Math.floor(Math.pow(4, (size + 1) / 2))
 
-const bodySize = 12
+const bodySize = 10
 
 const headerWeight = 400
 const bodyWeight = 300


### PR DESCRIPTION
Reducing the resume font size from 12 to 10. The font size is too large on printed PDF documents. 