### PR TITLE
28-indicate-that-some-fields-are-more-or-less-required

### DIFF
--- a/src/components/dom/EmploymentHistorySectionForm.tsx
+++ b/src/components/dom/EmploymentHistorySectionForm.tsx
@@ -126,6 +126,7 @@ export const EmploymentForm: FunctionComponent<{
   >
     <PropTextEditor
       label="Worked as"
+      required
       placeholder="Job Title"
       propName="jobTitle"
       value={props.employment}
@@ -164,6 +165,7 @@ export const EmploymentForm: FunctionComponent<{
         label="from"
         placeholder="Start Date"
         propName="startDate"
+        required
         value={props.employment}
         setValue={props.setEmployment}
         variant="filled"

--- a/src/components/dom/PropTextEditor.tsx
+++ b/src/components/dom/PropTextEditor.tsx
@@ -7,11 +7,14 @@ export const PropTextEditor = <T,>(
     value: T
     propName: keyof T
     setValue: Setter<T>
+    required?: boolean
   } & Omit<TextFieldProps, 'value' | 'onChange'>,
 ): JSX.Element => {
-  const { value, setValue, propName, ...textFieldProps } = props
+  const { value, setValue, propName, required, ...textFieldProps } = props
   return (
     <TextField
+      error={required && value[propName] === ''}
+      required={required}
       value={value[propName]}
       onChange={({ target }) =>
         setValue((oldValue) => ({


### PR DESCRIPTION
Adds a required attribute to some fields in the editor's employment history view.