### PR TITLE
30-skip-rendering-of-fields-in-resume-if-blank

### DIFF
--- a/src/components/dom/PersonalDetailsForm.tsx
+++ b/src/components/dom/PersonalDetailsForm.tsx
@@ -46,18 +46,18 @@ export const PersonalDetailsForm: FunctionComponent<{
     <Stack gap={2}>
       <PropTextEditor
         variant="filled"
-        label="Country"
+        label="Location"
         propName="location"
         value={props.resume}
         setValue={props.setResume}
       />
-      <PropTextEditor
-        variant="filled"
-        label="Nationality"
-        propName="nationality"
-        value={props.resume}
-        setValue={props.setResume}
-      />
+      {/*<PropTextEditor*/}
+      {/*  variant="filled"*/}
+      {/*  label="Nationality"*/}
+      {/*  propName="nationality"*/}
+      {/*  value={props.resume}*/}
+      {/*  setValue={props.setResume}*/}
+      {/*/>*/}
       <PropTextEditor
         variant="filled"
         label="Email Address"

--- a/src/resume-view/templates/default/ContactDetailsView.tsx
+++ b/src/resume-view/templates/default/ContactDetailsView.tsx
@@ -6,18 +6,22 @@ import { Link, Text } from '@/resume-view/primitives'
 
 export const ContactDetailsView: FunctionComponent<{
   resume: Resume
-}> = (props) => (
-  <Stack
-    style={defaultTheme.typography.caption}
-    wrap={false}
-  >
-    {/*<Text style={{...theme.typography.header2}}>Contact Details</Text>*/}
-    <Link src={`mailto:${props.resume.emailAddress}`}>
-      <Text style={defaultTheme.typography.link}>
-        {props.resume.emailAddress}
-      </Text>
-    </Link>
-    <Text>{props.resume.phoneNumber}</Text>
-    <Text>{props.resume.location}</Text>
-  </Stack>
-)
+}> = (props) => {
+  const {
+    resume: { emailAddress, phoneNumber, location },
+  } = props
+  return (
+    <Stack
+      style={defaultTheme.typography.caption}
+      wrap={false}
+    >
+      {emailAddress && (
+        <Link src={`mailto:${emailAddress}`}>
+          <Text style={defaultTheme.typography.link}>{emailAddress}</Text>
+        </Link>
+      )}
+      {phoneNumber && <Text>{phoneNumber}</Text>}
+      {location && <Text>{location}</Text>}
+    </Stack>
+  )
+}

--- a/src/resume-view/templates/default/DetailsSectionView.tsx
+++ b/src/resume-view/templates/default/DetailsSectionView.tsx
@@ -7,15 +7,20 @@ import { Style, Text } from '@/resume-view/primitives'
 export const DetailsSectionView: FunctionComponent<{
   section: DetailsSection
   style?: Style | undefined
-}> = (props) => (
-  <Stack
-    style={props.style}
-    gap={3}
-    wrap={false}
-  >
-    <Text style={{ ...defaultTheme.typography.header2 }}>
-      {props.section.header}
-    </Text>
-    <Text>{props.section.description}</Text>
-  </Stack>
-)
+}> = (props) => {
+  const {
+    section: { header, description },
+  } = props
+  return (
+    <Stack
+      style={props.style}
+      gap={3}
+      wrap={false}
+    >
+      {header && (
+        <Text style={{ ...defaultTheme.typography.header2 }}>{header}</Text>
+      )}
+      {description && <Text>{description}</Text>}
+    </Stack>
+  )
+}

--- a/src/resume-view/templates/default/EmploymentView/EmploymentView.tsx
+++ b/src/resume-view/templates/default/EmploymentView/EmploymentView.tsx
@@ -43,17 +43,22 @@ export const EmploymentView: FunctionComponent<{
         />
       </Stack>
       <Stack gap={1}>
-        {props.employment.achievements.map((achievement) => (
-          <View
-            key={achievement.uid}
-            style={{
-              flexDirection: 'row',
-            }}
-          >
-            <Text>•</Text>
-            <Text style={styles.achievement}>{achievement.description}</Text>
-          </View>
-        ))}
+        {props.employment.achievements.map(
+          (achievement) =>
+            achievement.description !== '' && (
+              <View
+                key={achievement.uid}
+                style={{
+                  flexDirection: 'row',
+                }}
+              >
+                <Text>•</Text>
+                <Text style={styles.achievement}>
+                  {achievement.description}
+                </Text>
+              </View>
+            ),
+        )}
       </Stack>
     </Stack>
   )

--- a/src/resume-view/templates/default/EmploymentView/EmploymentView.tsx
+++ b/src/resume-view/templates/default/EmploymentView/EmploymentView.tsx
@@ -25,6 +25,9 @@ export const EmploymentView: FunctionComponent<{
   style?: Style | undefined
 }> = (props) => {
   const { employment } = props
+  const achievements = employment.achievements.filter(
+    ({ description }) => description !== '',
+  )
   return (
     <Stack
       style={props.style}
@@ -42,24 +45,21 @@ export const EmploymentView: FunctionComponent<{
           endDate={employment.endDate}
         />
       </Stack>
-      <Stack gap={1}>
-        {props.employment.achievements.map(
-          (achievement) =>
-            achievement.description !== '' && (
-              <View
-                key={achievement.uid}
-                style={{
-                  flexDirection: 'row',
-                }}
-              >
-                <Text>•</Text>
-                <Text style={styles.achievement}>
-                  {achievement.description}
-                </Text>
-              </View>
-            ),
-        )}
-      </Stack>
+      {achievements.length > 0 && (
+        <Stack gap={1}>
+          {achievements.map((achievement) => (
+            <View
+              key={achievement.uid}
+              style={{
+                flexDirection: 'row',
+              }}
+            >
+              <Text>•</Text>
+              <Text style={styles.achievement}>{achievement.description}</Text>
+            </View>
+          ))}
+        </Stack>
+      )}
     </Stack>
   )
 }

--- a/src/resume-view/templates/default/Header.tsx
+++ b/src/resume-view/templates/default/Header.tsx
@@ -33,18 +33,23 @@ const styles = createStyles({
 
 export const Header: FunctionComponent<{
   resume: Resume
-}> = (props) => (
-  <View style={styles.root}>
-    {props.resume.image && (
-      <Image
-        src={props.resume.image}
-        style={styles.image}
-      />
-    )}
-    <View style={styles.textSection}>
-      <Text style={styles.name}>{props.resume.name}</Text>
-      <Text style={styles.title}>{props.resume.jobTitle}</Text>
+}> = (props) => {
+  const {
+    resume: { name, jobTitle, image },
+  } = props
+  return (
+    <View style={styles.root}>
+      {image && (
+        <Image
+          src={image}
+          style={styles.image}
+        />
+      )}
+      <View style={styles.textSection}>
+        {name && <Text style={styles.name}>{name}</Text>}
+        {jobTitle && <Text style={styles.title}>{jobTitle}</Text>}
+      </View>
+      <ContactDetailsView resume={props.resume} />
     </View>
-    <ContactDetailsView resume={props.resume} />
-  </View>
-)
+  )
+}

--- a/src/resume-view/templates/default/SkillSectionView.tsx
+++ b/src/resume-view/templates/default/SkillSectionView.tsx
@@ -21,9 +21,11 @@ export const SkillSectionView: FunctionComponent<{
       wrap={false}
       gap={3}
     >
-      <Text style={{ ...defaultTheme.typography.header2 }}>
-        {props.section.header}
-      </Text>
+      {props.section.header && (
+        <Text style={{ ...defaultTheme.typography.header2 }}>
+          {props.section.header}
+        </Text>
+      )}
       {props.section.skillCategories.slice(0, 1).map((skillCategory, index) => (
         <SkillCategoryView
           key={index}
@@ -47,18 +49,22 @@ export const SkillCategoryView: FunctionComponent<{
     gap={2}
     wrap={false}
   >
-    <Text style={{ ...defaultTheme.typography.header3 }}>
-      {skillCategory.header}
-    </Text>
-    <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
-      {skillCategory.skills.map((skill) => (
-        <Text
-          key={skill.uid}
-          style={{ marginRight: defaultTheme.spacing(2) }}
-        >
-          {skill.label}
-        </Text>
-      ))}
-    </View>
+    {skillCategory.header && (
+      <Text style={{ ...defaultTheme.typography.header3 }}>
+        {skillCategory.header}
+      </Text>
+    )}
+    {skillCategory.skills.length > 0 && (
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+        {skillCategory.skills.map((skill) => (
+          <Text
+            key={skill.uid}
+            style={{ marginRight: defaultTheme.spacing(2) }}
+          >
+            {skill.label}
+          </Text>
+        ))}
+      </View>
+    )}
   </Stack>
 )


### PR DESCRIPTION
Improve the rendered resume's appearence by omitting empty divs: 

- Hiding the Nationality field, as it's not used.
- Renaming the Country field to Location.
- Hiding the lists of achievements if there are none.
- Hiding individual achievements if blank.
- Hiding contact details if blank.
- Hiding name and jobTitle if blank.
- Hiding skill section header when blank
- Hiding skill category header when blank
- Hiding blank fields from DetailsSectionView.tsx