### PR TITLE
35-pdf-page-has-no-margin

### DIFF
--- a/src/resume-view/PdfResume.tsx
+++ b/src/resume-view/PdfResume.tsx
@@ -1,19 +1,13 @@
 import React, { FunctionComponent, ReactNode } from 'react'
 import { ResumeTargetProvider } from '@/resume-view/ResumeTargetProvider'
-import { Document, Page } from '@react-pdf/renderer'
-import { PageCount } from '@/resume-view/PageCount'
+import { Document } from '@react-pdf/renderer'
 
 export const PdfResumeDocument: FunctionComponent<{
   children?: ReactNode
 }> = (props) => {
   return (
     <Document>
-      <Page size="A4">
-        <ResumeTargetProvider target="pdf">
-          {props.children}
-        </ResumeTargetProvider>
-        <PageCount />
-      </Page>
+      <ResumeTargetProvider target="pdf">{props.children}</ResumeTargetProvider>
     </Document>
   )
 }

--- a/src/resume-view/primitives/Page.tsx
+++ b/src/resume-view/primitives/Page.tsx
@@ -1,27 +1,27 @@
 import * as React from 'react'
 import { FunctionComponent, ReactNode } from 'react'
-import { domStyles, pdfStyles, Style } from '@/resume-view/primitives/Styles'
 import { useResumeTarget } from '@/resume-view/ResumeTargetProvider'
-import { Text as PdfText } from '@react-pdf/renderer'
-
-export const Text: FunctionComponent<{
+import { Page as PdfPage } from '@react-pdf/renderer'
+import { domStyles, pdfStyles, Style } from '@/resume-view/primitives/Styles'
+export const Page: FunctionComponent<{
   children?: ReactNode
   style?: Style
-  render?: (args: { pageNumber: number; totalPages: number }) => ReactNode
+  wrap?: boolean
 }> = (props) => {
-  const { style, children, render } = props
+  const { style, children, wrap } = props
   const target = useResumeTarget()
   if (target === 'pdf') {
     return (
-      <PdfText
+      <PdfPage
+        size="A4"
         style={pdfStyles(style)}
-        render={render}
+        wrap={wrap}
       >
         {children}
-      </PdfText>
+      </PdfPage>
     )
   } else if (target === 'dom') {
-    return <span style={domStyles(style)}>{children}</span>
+    return <div style={domStyles(style)}>{children}</div>
   } else {
     throw new Error(
       'Resume target is undefined. Wrap the resume with PdfResume or DomResume',

--- a/src/resume-view/primitives/View.tsx
+++ b/src/resume-view/primitives/View.tsx
@@ -8,20 +8,22 @@ export const View: FunctionComponent<{
   children?: ReactNode
   style?: Style
   wrap?: boolean
+  fixed?: boolean
 }> = (props) => {
-  const { style, children, wrap } = props
+  const { style, children, wrap, fixed } = props
   const target = useResumeTarget()
   if (target === 'pdf') {
     return (
       <PdfView
         style={pdfStyles(style)}
         wrap={wrap}
+        fixed={fixed}
       >
         {children}
       </PdfView>
     )
   } else if (target === 'dom') {
-    return <div style={domStyles(style)}>{children}</div>
+    return fixed ? null : <div style={domStyles(style)}>{children}</div>
   } else {
     throw new Error(
       'Resume target is undefined. Wrap the resume with PdfResume or DomResume',

--- a/src/resume-view/templates/default/DefaultTemplate.tsx
+++ b/src/resume-view/templates/default/DefaultTemplate.tsx
@@ -3,8 +3,10 @@ import { Resume } from '@/model/resume'
 import { Stack } from '@/resume-view/base-components'
 import { Header } from '@/resume-view/templates/default/Header'
 import { defaultTheme } from '@/resume-view/Theme'
-import { createStyles, View } from '@/resume-view/primitives'
+import { createStyles } from '@/resume-view/primitives'
 import { SectionView } from '@/resume-view/templates/default/SectionView'
+import { Page } from '@/resume-view/primitives/Page'
+import { PageCount } from '@/resume-view/templates/default/PageCount'
 
 const styles = createStyles({
   page: {
@@ -21,7 +23,7 @@ const styles = createStyles({
 export const DefaultTemplate: FunctionComponent<{
   resume: Resume
 }> = (props) => (
-  <View style={styles.page}>
+  <Page style={styles.page}>
     <Stack gap={4}>
       <Header resume={props.resume} />
       {props.resume.sections.map((section, index) => (
@@ -31,5 +33,6 @@ export const DefaultTemplate: FunctionComponent<{
         />
       ))}
     </Stack>
-  </View>
+    <PageCount />
+  </Page>
 )

--- a/src/resume-view/templates/default/PageCount.tsx
+++ b/src/resume-view/templates/default/PageCount.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react'
-import { StyleSheet, Text, View } from '@react-pdf/renderer'
 import { defaultTheme } from '@/resume-view/Theme'
+import { createStyles, Text, View } from '@/resume-view/primitives'
 
-const styles = StyleSheet.create({
+const styles = createStyles({
   view: {
     position: 'absolute',
     bottom: 0,


### PR DESCRIPTION
Fixing margins on PDF document. The margins didn't work because the page margins were accidentally applied to a view within the page.

- Adding render prop to primitives/Text.
- Adding fixed prop to primitives/View.
- Adding new primitive component Page.
- Using Page within the default template.